### PR TITLE
reading compilerOptions from deno.json

### DIFF
--- a/src/esm-sh.ts
+++ b/src/esm-sh.ts
@@ -122,6 +122,7 @@ export async function transpile(
     bundle: true, // need for resolve import
     logLevel: options.debug ? "debug" : "info",
     format: "esm",
+    tsconfig: options.denoConfigPath,
   });
   if (b.outputFiles === undefined) {
     if (b.errors.length > 0) {

--- a/src/subcommands/bundle.ts
+++ b/src/subcommands/bundle.ts
@@ -100,6 +100,7 @@ export async function main(
           logLevel: options.debug ? "debug" : "info",
           format: "esm",
           outdir: options.outdir,
+          tsconfig: denoConfigPath,
           outExtension: {
             ".js": ".mjs",
           },


### PR DESCRIPTION
e.g. with

deno.json

```json
{
    "compilerOptions": {
        "jsx": "react-jsx",
        "jsxImportSource": "npm:react@19",
        "jsxImportSourceTypes": "npm:@types/react@19"
    }
}
```

We don't have to adding custom hints for babel plugin, something like..

```tsx
/** @jsxRuntime automatic */
/** @jsxImportSource npm:react@18 */
/** @jsxImportSourceTypes npm:@types/react@18 */

```